### PR TITLE
Add Python implementation for soil temperature model

### DIFF
--- a/phase_change.py
+++ b/phase_change.py
@@ -1,0 +1,65 @@
+import numpy as np
+
+
+def phase_change(physcon, soilvar, dt):
+    """Adjust temperatures for phase change using excess heat."""
+    soilvar['hfsoi'] = 0.0
+    nsoi = soilvar['nsoi']
+
+    for i in range(nsoi):
+        wliq0 = soilvar['h2osoi_liq'][i]
+        wice0 = soilvar['h2osoi_ice'][i]
+        wmass0 = wliq0 + wice0
+        tsoi0 = soilvar['tsoi'][i]
+
+        imelt = 0
+        if soilvar['h2osoi_ice'][i] > 0 and soilvar['tsoi'][i] > physcon.tfrz:
+            imelt = 1
+            soilvar['tsoi'][i] = physcon.tfrz
+        if soilvar['h2osoi_liq'][i] > 0 and soilvar['tsoi'][i] < physcon.tfrz:
+            imelt = 2
+            soilvar['tsoi'][i] = physcon.tfrz
+
+        if imelt > 0:
+            heat_flux_pot = (soilvar['tsoi'][i] - tsoi0) * soilvar['cv'][i] * soilvar['dz'][i] / dt
+        else:
+            heat_flux_pot = 0.0
+
+        if imelt == 1:
+            heat_flux_max = -soilvar['h2osoi_ice'][i] * physcon.hfus / dt
+        elif imelt == 2:
+            heat_flux_max = soilvar['h2osoi_liq'][i] * physcon.hfus / dt
+
+        if imelt > 0:
+            ice_flux = heat_flux_pot / physcon.hfus
+            soilvar['h2osoi_ice'][i] = wice0 + ice_flux * dt
+            soilvar['h2osoi_ice'][i] = max(0.0, soilvar['h2osoi_ice'][i])
+            soilvar['h2osoi_ice'][i] = min(wmass0, soilvar['h2osoi_ice'][i])
+            soilvar['h2osoi_liq'][i] = max(0.0, (wmass0 - soilvar['h2osoi_ice'][i]))
+            heat_flux = physcon.hfus * (soilvar['h2osoi_ice'][i] - wice0) / dt
+            soilvar['hfsoi'] += heat_flux
+            residual = heat_flux_pot - heat_flux
+            soilvar['tsoi'][i] = soilvar['tsoi'][i] - residual * dt / (soilvar['cv'][i] * soilvar['dz'][i])
+
+            if abs(heat_flux) > abs(heat_flux_max) + 1e-12:
+                raise RuntimeError('Soil temperature energy conservation error: phase change')
+
+            if imelt == 2:
+                constraint = min(heat_flux_pot, heat_flux_max)
+                err = heat_flux - constraint
+                if abs(err) > 1e-3:
+                    raise RuntimeError('Soil temperature energy conservation error: freezing energy flux')
+                err = (soilvar['h2osoi_ice'][i] - wice0) - constraint / physcon.hfus * dt
+                if abs(err) > 1e-3:
+                    raise RuntimeError('Soil temperature energy conservation error: freezing ice flux')
+
+            if imelt == 1:
+                constraint = max(heat_flux_pot, heat_flux_max)
+                err = heat_flux - constraint
+                if abs(err) > 1e-3:
+                    raise RuntimeError('Soil temperature energy conservation error: thawing energy flux')
+                err = (soilvar['h2osoi_ice'][i] - wice0) - constraint / physcon.hfus * dt
+                if abs(err) > 1e-3:
+                    raise RuntimeError('Soil temperature energy conservation error: thawing ice flux')
+
+    return soilvar

--- a/soil_temperature.py
+++ b/soil_temperature.py
@@ -1,0 +1,60 @@
+import numpy as np
+from tridiagonal_solver import tridiagonal_solver
+from phase_change import phase_change
+
+
+def soil_temperature(physcon, soilvar, tsurf, dt):
+    """Solve for soil temperature using an implicit formulation."""
+    nsoi = soilvar['nsoi']
+    tsoi0 = soilvar['tsoi'].copy()
+
+    tk_plus_onehalf = np.zeros(nsoi - 1)
+    for i in range(nsoi - 1):
+        numerator = soilvar['tk'][i] * soilvar['tk'][i + 1] * (soilvar['z'][i] - soilvar['z'][i + 1])
+        denominator = (
+            soilvar['tk'][i] * (soilvar['z_plus_onehalf'][i] - soilvar['z'][i + 1])
+            + soilvar['tk'][i + 1] * (soilvar['z'][i] - soilvar['z_plus_onehalf'][i])
+        )
+        tk_plus_onehalf[i] = numerator / denominator
+
+    a = np.zeros(nsoi)
+    b = np.zeros(nsoi)
+    c = np.zeros(nsoi)
+    d = np.zeros(nsoi)
+
+    i = 0
+    m = soilvar['cv'][i] * soilvar['dz'][i] / dt
+    a[i] = 0.0
+    c[i] = -tk_plus_onehalf[i] / soilvar['dz_plus_onehalf'][i]
+    b[i] = m - c[i] + soilvar['tk'][i] / (0.0 - soilvar['z'][i])
+    d[i] = m * soilvar['tsoi'][i] + soilvar['tk'][i] / (0.0 - soilvar['z'][i]) * tsurf
+
+    for i in range(1, nsoi - 1):
+        m = soilvar['cv'][i] * soilvar['dz'][i] / dt
+        a[i] = -tk_plus_onehalf[i - 1] / soilvar['dz_plus_onehalf'][i - 1]
+        c[i] = -tk_plus_onehalf[i] / soilvar['dz_plus_onehalf'][i]
+        b[i] = m - a[i] - c[i]
+        d[i] = m * soilvar['tsoi'][i]
+
+    i = nsoi - 1
+    m = soilvar['cv'][i] * soilvar['dz'][i] / dt
+    a[i] = -tk_plus_onehalf[i - 1] / soilvar['dz_plus_onehalf'][i - 1]
+    c[i] = 0.0
+    b[i] = m - a[i]
+    d[i] = m * soilvar['tsoi'][i]
+
+    soilvar['tsoi'] = tridiagonal_solver(a, b, c, d)
+
+    soilvar['gsoi'] = soilvar['tk'][0] * (tsurf - soilvar['tsoi'][0]) / (0.0 - soilvar['z'][0])
+
+    if soilvar['method'] == 'apparent-heat-capacity':
+        soilvar['hfsoi'] = 0.0
+    elif soilvar['method'] == 'excess-heat':
+        soilvar = phase_change(physcon, soilvar, dt)
+
+    edif = np.sum(soilvar['cv'] * soilvar['dz'] * (soilvar['tsoi'] - tsoi0) / dt)
+    err = edif - soilvar['gsoi'] - soilvar.get('hfsoi', 0.0)
+    if abs(err) > 1e-3:
+        raise RuntimeError('Soil temperature energy conservation error')
+
+    return soilvar

--- a/soil_thermal_properties.py
+++ b/soil_thermal_properties.py
@@ -1,0 +1,70 @@
+import numpy as np
+
+
+def soil_thermal_properties(physcon, soilvar):
+    """Calculate soil thermal conductivity and heat capacity."""
+    nsoi = soilvar['nsoi']
+    texture = soilvar['soil_texture'] - 1  # zero-based index
+
+    for i in range(nsoi):
+        watliq = soilvar['h2osoi_liq'][i] / (physcon.rhowat * soilvar['dz'][i])
+        watice = soilvar['h2osoi_ice'][i] / (physcon.rhoice * soilvar['dz'][i])
+
+        if watliq + watice > 0:
+            fliq = watliq / (watliq + watice)
+        else:
+            fliq = 0.0
+
+        s = min((watliq + watice) / soilvar['watsat'][texture], 1.0)
+
+        bd = 2700 * (1 - soilvar['watsat'][texture])
+        tkdry = (0.135 * bd + 64.7) / (2700 - 0.947 * bd)
+
+        tk_quartz = 7.7
+        quartz = soilvar['sand'][texture] / 100.0
+        tko = 2.0 if quartz > 0.2 else 3.0
+        tksol = tk_quartz ** quartz * tko ** (1 - quartz)
+
+        tksat = (
+            tksol ** (1 - soilvar['watsat'][texture])
+            * physcon.tkwat ** (fliq * soilvar['watsat'][texture])
+            * physcon.tkice ** (soilvar['watsat'][texture] - fliq * soilvar['watsat'][texture])
+        )
+        tksat_u = tksol ** (1 - soilvar['watsat'][texture]) * physcon.tkwat ** soilvar['watsat'][texture]
+        tksat_f = tksol ** (1 - soilvar['watsat'][texture]) * physcon.tkice ** soilvar['watsat'][texture]
+
+        if soilvar['sand'][texture] < 50:
+            ke_u = np.log10(max(s, 0.1)) + 1.0
+        else:
+            ke_u = 0.7 * np.log10(max(s, 0.05)) + 1.0
+        ke_f = s
+
+        ke = ke_u if soilvar['tsoi'][i] >= physcon.tfrz else ke_f
+
+        soilvar['tk'][i] = (tksat - tkdry) * ke + tkdry
+        tku = (tksat_u - tkdry) * ke_u + tkdry
+        tkf = (tksat_f - tkdry) * ke_f + tkdry
+
+        cvsol = 1.926e6
+        soilvar['cv'][i] = (
+            (1 - soilvar['watsat'][texture]) * cvsol
+            + physcon.cvwat * watliq
+            + physcon.cvice * watice
+        )
+        cvu = (1 - soilvar['watsat'][texture]) * cvsol + physcon.cvwat * (watliq + watice)
+        cvf = (1 - soilvar['watsat'][texture]) * cvsol + physcon.cvice * (watliq + watice)
+
+        if soilvar['method'] == 'apparent-heat-capacity':
+            tinc = 0.5
+            ql = physcon.hfus * (physcon.rhowat * watliq + physcon.rhoice * watice)
+            if soilvar['tsoi'][i] > physcon.tfrz + tinc:
+                soilvar['cv'][i] = cvu
+                soilvar['tk'][i] = tku
+            elif physcon.tfrz - tinc <= soilvar['tsoi'][i] <= physcon.tfrz + tinc:
+                soilvar['cv'][i] = (cvf + cvu) / 2 + ql / (2 * tinc)
+                soilvar['tk'][i] = tkf + (tku - tkf) * (soilvar['tsoi'][i] - physcon.tfrz + tinc) / (2 * tinc)
+            else:
+                soilvar['cv'][i] = cvf
+                soilvar['tk'][i] = tkf
+
+    return soilvar

--- a/sp_05_02.py
+++ b/sp_05_02.py
@@ -1,0 +1,118 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+from dataclasses import dataclass
+from soil_thermal_properties import soil_thermal_properties
+from soil_temperature import soil_temperature
+
+
+@dataclass
+class PhysCon:
+    tfrz: float = 273.15
+    cwat: float = 4188.0
+    cice: float = 2117.27
+    rhowat: float = 1000.0
+    rhoice: float = 917.0
+    tkwat: float = 0.57
+    tkice: float = 2.29
+    hfus: float = 0.3337e6
+
+    @property
+    def cvwat(self):
+        return self.cwat * self.rhowat
+
+    @property
+    def cvice(self):
+        return self.cice * self.rhoice
+
+
+def main():
+    physcon = PhysCon()
+
+    soilvar = {
+        'silt': np.array([5.0, 12.0, 32.0, 70.0, 39.0, 15.0, 56.0, 34.0, 6.0, 47.0, 20.0]),
+        'sand': np.array([92.0, 82.0, 58.0, 17.0, 43.0, 58.0, 10.0, 32.0, 52.0, 6.0, 22.0]),
+        'clay': np.array([3.0, 6.0, 10.0, 13.0, 18.0, 27.0, 34.0, 34.0, 42.0, 47.0, 58.0]),
+        'watsat': np.array([0.395, 0.410, 0.435, 0.485, 0.451, 0.420, 0.477, 0.476, 0.426, 0.492, 0.482]),
+        'soil_texture': 1,
+        'method': 'excess-heat',
+    }
+
+    tmean = physcon.tfrz + 15.0
+    trange = 10.0
+    dt = 1800
+    nday = 200
+
+    nsoi = 120
+    soilvar['nsoi'] = nsoi
+    soilvar['dz'] = np.full(nsoi, 0.025)
+
+    soilvar['z_plus_onehalf'] = np.zeros(nsoi)
+    soilvar['z_plus_onehalf'][0] = -soilvar['dz'][0]
+    for i in range(1, nsoi):
+        soilvar['z_plus_onehalf'][i] = soilvar['z_plus_onehalf'][i - 1] - soilvar['dz'][i]
+
+    soilvar['z'] = np.zeros(nsoi)
+    soilvar['z'][0] = 0.5 * soilvar['z_plus_onehalf'][0]
+    for i in range(1, nsoi):
+        soilvar['z'][i] = 0.5 * (soilvar['z_plus_onehalf'][i - 1] + soilvar['z_plus_onehalf'][i])
+
+    soilvar['dz_plus_onehalf'] = np.zeros(nsoi)
+    for i in range(nsoi - 1):
+        soilvar['dz_plus_onehalf'][i] = soilvar['z'][i] - soilvar['z'][i + 1]
+    soilvar['dz_plus_onehalf'][-1] = 0.5 * soilvar['dz'][-1]
+
+    soilvar['tsoi'] = np.full(nsoi, physcon.tfrz + 2.0)
+    h2osoi_sat = soilvar['watsat'][soilvar['soil_texture'] - 1] * physcon.rhowat * soilvar['dz']
+    soilvar['h2osoi_liq'] = np.where(soilvar['tsoi'] > physcon.tfrz, 0.8 * h2osoi_sat, 0.0)
+    soilvar['h2osoi_ice'] = np.where(soilvar['tsoi'] <= physcon.tfrz, 0.8 * h2osoi_sat, 0.0)
+
+    soilvar['tk'] = np.zeros(nsoi)
+    soilvar['cv'] = np.zeros(nsoi)
+    soilvar['gsoi'] = 0.0
+    soilvar['hfsoi'] = 0.0
+
+    ntim = round(86400 / dt)
+    hour_vec = []
+    z_vec = []
+    tsoi_vec = []
+    hour_out = np.zeros(ntim)
+    z_out = np.zeros(nsoi + 1)
+    tsoi_out = np.zeros((nsoi + 1, ntim))
+
+    for iday in range(1, nday + 1):
+        print(f"day = {iday:6.0f}")
+        for itim in range(1, ntim + 1):
+            hour = itim * (dt / 86400 * 24)
+            tsurf = tmean + 0.5 * trange * np.sin(2 * np.pi / 24 * (hour - 8.0))
+
+            soilvar = soil_thermal_properties(physcon, soilvar)
+            soilvar = soil_temperature(physcon, soilvar, tsurf, dt)
+
+            if iday == nday:
+                hour_vec.append(hour)
+                z_vec.append(0.0)
+                tsoi_vec.append(tsurf - physcon.tfrz)
+                hour_out[itim - 1] = hour
+                tsoi_out[0, itim - 1] = tsurf - physcon.tfrz
+                z_out[0] = 0.0
+                for i in range(nsoi):
+                    if soilvar['z'][i] > -1.0:
+                        hour_vec.append(hour)
+                        z_vec.append(soilvar['z'][i] * 100.0)
+                        tsoi_vec.append(soilvar['tsoi'][i] - physcon.tfrz)
+                        z_out[i + 1] = soilvar['z'][i] * 100.0
+                        tsoi_out[i + 1, itim - 1] = soilvar['tsoi'][i] - physcon.tfrz
+
+    A = np.vstack([hour_vec, z_vec, tsoi_vec]).T
+    np.savetxt('data.txt', A, fmt='%12.3f', header='hour z tsoi', comments='')
+
+    plt.contour(hour_out, z_out, tsoi_out, levels=15)
+    plt.title('Soil Temperature (°C)')
+    plt.xlabel('Time of day (hours)')
+    plt.ylabel('Soil depth (cm)')
+    plt.show()
+
+
+if __name__ == '__main__':
+    main()

--- a/tridiagonal_solver.py
+++ b/tridiagonal_solver.py
@@ -1,0 +1,22 @@
+import numpy as np
+
+def tridiagonal_solver(a, b, c, d):
+    """Solve a tridiagonal system for u given a, b, c, d."""
+    n = len(d)
+    e = np.zeros(n)
+    f = np.zeros(n)
+
+    e[0] = c[0] / b[0]
+    for i in range(1, n-1):
+        e[i] = c[i] / (b[i] - a[i] * e[i-1])
+
+    f[0] = d[0] / b[0]
+    for i in range(1, n):
+        f[i] = (d[i] - a[i] * f[i-1]) / (b[i] - a[i] * e[i-1])
+
+    u = np.zeros(n)
+    u[-1] = f[-1]
+    for i in range(n-2, -1, -1):
+        u[i] = f[i] - e[i] * u[i+1]
+
+    return u


### PR DESCRIPTION
## Summary
- port MATLAB soil temperature solver to Python (`sp_05_02.py`)
- add Python versions of helper routines: thermal properties, phase change and solver
- include tri-diagonal solver for implicit temperature calculation

## Testing
- `python sp_05_02.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6843428ccc888330b0a2822b2ebfa8e0